### PR TITLE
fix: MatchClassMethod 注入的实例字段加 transient，修复 Serializable 类序列化崩溃

### DIFF
--- a/android-aop-plugin/src/main/kotlin/com/flyjingfish/android_aop_plugin/scanner_visitor/WovenIntoCode.kt
+++ b/android-aop-plugin/src/main/kotlin/com/flyjingfish/android_aop_plugin/scanner_visitor/WovenIntoCode.kt
@@ -475,7 +475,7 @@ object WovenIntoCode {
                         ctClass.addField(extraField, CtField.Initializer.byExpr("new $JOIN_LOCK()"));
                     }else{
                         val extraField = CtField(cp.get(JOIN_POINT_CLASS), targetFieldName, ctClass)
-                        extraField.modifiers = Modifier.PRIVATE or Modifier.VOLATILE
+                        extraField.modifiers = Modifier.PRIVATE or Modifier.VOLATILE or Modifier.TRANSIENT
                         ctClass.addField(extraField)
                     }
 


### PR DESCRIPTION
## 问题

用 `@AndroidAopMatchClassMethod`（`type = MatchType.SELF`）切一个 `implements Serializable` 类的**实例方法**后，AndroidAOP 会往该类注入一个缓存 JoinPoint 的实例字段：

```
private volatile AndroidAopJoinPoint xxx$$AndroidAOPField;
```

该字段类型不可序列化，且未标 `transient`。于是把该类的对象通过 Intent/Bundle 传递（走 Java 序列化）时崩溃：

```
android.os.BadParcelableException: Parcelable encountered IOException writing serializable object
```

详见 #96。

## 修复

`WovenIntoCode.kt` 注入实例字段时给 modifier 加上 `Modifier.TRANSIENT`：

```kotlin
extraField.modifiers = Modifier.PRIVATE or Modifier.VOLATILE or Modifier.TRANSIENT
```

该字段已有 `if (field == null) { ... }` 懒初始化逻辑，标 `transient` 后反序列化为 null 会自动重建，**不影响 AOP 功能**。静态方法那条分支用的是 `private static final` 字段，不参与实例序列化，无需改动。

## 验证

在真实工程中本地发布修复版插件并打 release 包验证：

1. 反编译产物：被 hook 的 `Serializable` 类注入字段变为 `private volatile transient ...$$AndroidAOPField`；
2. 原先必崩的 Intent 传递场景不再 `BadParcelableException`；
3. AOP 拦截功能正常。

closes #96
